### PR TITLE
feat(zodResolver): add an option to zodResolver for errorPriority

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,16 @@ form.errors;
 // }
 ```
 
+## API:
+
+### ZodResolverOptions
+
+`zodResolver` takes as an optional second parameter some `zodResolverOptions`.
+
+| Name            | Type                           | Description                                                                                                                                                                                                                        |
+| --------------- | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `errorPriority` | `first` \| `last` \| undefined | In case a field can display multiple error message, set `errorPriority` to `first` to display the message of the first failing check, or set `errorPriority` to `last` to display the message of the last failing check (default). |
+
 ## License
 
 MIT

--- a/src/zod-resolver.ts
+++ b/src/zod-resolver.ts
@@ -1,7 +1,11 @@
 import type { Schema } from 'zod';
 import type { FormErrors } from '@mantine/form';
 
-export function zodResolver(schema: Schema) {
+export interface ZodResolverOptions {
+  errorPriority?: 'first' | 'last';
+}
+
+export function zodResolver(schema: Schema, options?: ZodResolverOptions) {
   return (values: Record<string, unknown>): FormErrors => {
     const parsed = schema.safeParse(values);
 
@@ -12,6 +16,9 @@ export function zodResolver(schema: Schema) {
     const results: FormErrors = {};
 
     if ('error' in parsed) {
+      if (options?.errorPriority === 'first') {
+        parsed.error.errors.reverse();
+      }
       parsed.error.errors.forEach((error) => {
         results[error.path.join('.')] = error.message;
       });


### PR DESCRIPTION
Following this discussion (https://github.com/mantinedev/mantine/pull/5412#issuecomment-1852664476) on Mantine/core, I propose to a add an option to have the possibility to display first error message instead of last one.

### Use case

```typescript

const check = z.object({
  hashtag: z
    .string()
    .refine((value) => value.length > 0, {
      message: 'Hashtag should not be empty',
    })
    .refine((value) => value.includes('#'), {
      message: 'There must be a # in the hashtag',
    }),
});

zodResolver(check);

``` 

**Current behaviour**: if the input is "" the result for hashtag is 'There must be a # in the hashtag'
**Expected behaviour**: there should be an option to make the 'Hashtag should not be empty' appear

```typescript

zodResolver(check, { errorPriority: "first" }); // This would meet the expected behaviour

``` 