### PR TITLE
Upgrade to zod v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,10 +88,10 @@
     "typescript": "^5.2.2",
     "version-next": "^1.0.2",
     "yargs": "^17.7.2",
-    "zod": "^3.22.4"
+    "zod": "^3.25.0"
   },
   "peerDependencies": {
     "@mantine/form": ">=7.0.0",
-    "zod": ">=3.0.0"
+    "zod": ">=3.25.0"
   }
 }

--- a/src/zod-resolver.test.ts
+++ b/src/zod-resolver.test.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { act, renderHook } from '@testing-library/react';
 import { useForm } from '@mantine/form';
 import { ZodResolverOptions, zodResolver } from './zod-resolver';

--- a/src/zod-resolver.ts
+++ b/src/zod-resolver.ts
@@ -1,11 +1,11 @@
-import type { Schema } from 'zod';
+import type { ZodType} from 'zod/v4';
 import type { FormErrors } from '@mantine/form';
 
 export interface ZodResolverOptions {
   errorPriority?: 'first' | 'last';
 }
 
-export function zodResolver(schema: Schema, options?: ZodResolverOptions) {
+export function zodResolver(schema: ZodType, options?: ZodResolverOptions) {
   return (values: Record<string, unknown>): FormErrors => {
     const parsed = schema.safeParse(values);
 
@@ -17,9 +17,9 @@ export function zodResolver(schema: Schema, options?: ZodResolverOptions) {
 
     if ('error' in parsed) {
       if (options?.errorPriority === 'first') {
-        parsed.error.errors.reverse();
+        parsed.error.issues.reverse();
       }
-      parsed.error.errors.forEach((error) => {
+      parsed.error.issues.forEach((error) => {
         results[error.path.join('.')] = error.message;
       });
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "ES2015",
     "lib": ["DOM", "ESNext"],
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "jsx": "react",
     "skipLibCheck": true,
     "outDir": "temp",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5103,10 +5103,10 @@ __metadata:
     typescript: "npm:^5.2.2"
     version-next: "npm:^1.0.2"
     yargs: "npm:^17.7.2"
-    zod: "npm:^3.22.4"
+    zod: "npm:^3.25.0"
   peerDependencies:
     "@mantine/form": ">=7.0.0"
-    zod: ">=3.0.0"
+    zod: ">=3.25.0"
   languageName: unknown
   linkType: soft
 
@@ -7031,9 +7031,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^3.22.4":
-  version: 3.22.4
-  resolution: "zod@npm:3.22.4"
-  checksum: 7578ab283dac0eee66a0ad0fc4a7f28c43e6745aadb3a529f59a4b851aa10872b3890398b3160f257f4b6817b4ce643debdda4fb21a2c040adda7862cab0a587
+"zod@npm:^3.25.0":
+  version: 3.25.20
+  resolution: "zod@npm:3.25.20"
+  checksum: f3b3e8875e1e02ca25bbfd45332aa1010f1b252b60a619c94c15bd6de637f841d344a3975d6950b2fbee68db4160ddb534cb9571c517fac17983871739085278
   languageName: node
   linkType: hard


### PR DESCRIPTION
This PR adds support for zod v4.

Note that v4 is currently released as [v3.25](https://zod.dev/v4?id=versioning).

Most importantly, v4 doesn't work with the `node` `moduleResolution` option [as documented here](https://zod.dev/?id=moduleresolution). I changed the mode to `bundler`, but I do not know whether the other two modes would be more appropriate. See https://github.com/colinhacks/zod/issues/4372 for more information.